### PR TITLE
Fix Equipment Train Stop crash on entity removal

### DIFF
--- a/mods_2.0/040_glutenfree-equipment-train-stop/scripts/handler.lua
+++ b/mods_2.0/040_glutenfree-equipment-train-stop/scripts/handler.lua
@@ -91,7 +91,11 @@ function handler.on_object_destroyed(event)
           local inventory = entity.get_inventory(defines.inventory.chest)
           for slot = 1, #inventory do
             local stack = inventory[slot]
-            entity.surface.spill_item_stack({position = entity.position, stack = stack, enable_looted = false, force = nil, allow_belts = false})
+            entity.surface.spill_item_stack({
+              position = entity.position,
+              stack = stack,
+              allow_belts = false,
+            })
           end
         end
       end

--- a/mods_2.0/040_glutenfree-equipment-train-stop/scripts/handler.lua
+++ b/mods_2.0/040_glutenfree-equipment-train-stop/scripts/handler.lua
@@ -91,7 +91,7 @@ function handler.on_object_destroyed(event)
           local inventory = entity.get_inventory(defines.inventory.chest)
           for slot = 1, #inventory do
             local stack = inventory[slot]
-            entity.surface.spill_item_stack(entity.position, stack, false, nil, false)
+            entity.surface.spill_item_stack({position = entity.position, stack = stack, enable_looted = false, force = nil, allow_belts = false})
           end
         end
       end


### PR DESCRIPTION
Hello! I noticed this crash a while ago and fixed it locally, but forgot to submit a pull request here. Sorry about that!

In the current version of the Equipment Train Stop mod, the mod crashes when the Equipment Train Stop entity is removed (both if removed by a player or a construction robot). This is because the LuaSurface function "spill_item_stacks" expects a single table of fields instead of separate function arguments. After making the line change in this PR, the crash no longer happens.

If you have any questions or concerns, please let me know and I'll respond as soon as possible! Thank you!