### PR TITLE
Translatable equipment-train-stop messages

### DIFF
--- a/mods_2.0/040_glutenfree-equipment-train-stop/locale/de/lang.cfg
+++ b/mods_2.0/040_glutenfree-equipment-train-stop/locale/de/lang.cfg
@@ -2,3 +2,9 @@
 glutenfree-equipment-train-stop-tripwire=Auslöser
 glutenfree-equipment-train-stop-station=Ausrüstende Zughaltestelle
 glutenfree-equipment-train-stop-template-container=Schablonen für ausrüstende Zughaltestelle
+
+[glutenfree-equipment-train-stop]
+no-equipment-grid=Kein Ausrüstungsraster gefunden.
+template-chest-empty=Schablonenkiste ist leer.
+missing-template=Fehlende Schablone für __1__.
+template-equipment-grid-empty=Schablonen-Ausrüstungsraster ist leer.

--- a/mods_2.0/040_glutenfree-equipment-train-stop/locale/en/lang.cfg
+++ b/mods_2.0/040_glutenfree-equipment-train-stop/locale/en/lang.cfg
@@ -2,3 +2,9 @@
 glutenfree-equipment-train-stop-tripwire=Tripwire
 glutenfree-equipment-train-stop-station=Equipment train stop
 glutenfree-equipment-train-stop-template-container=Equipment train stop templates
+
+[glutenfree-equipment-train-stop]
+no-equipment-grid=No equipment grid found.
+template-chest-empty=Template chest is empty.
+missing-template=Missing template for __1__.
+template-equipment-grid-empty=Template equipment grid empty.

--- a/mods_2.0/040_glutenfree-equipment-train-stop/scripts/equipmentgrid.lua
+++ b/mods_2.0/040_glutenfree-equipment-train-stop/scripts/equipmentgrid.lua
@@ -1,5 +1,7 @@
 require("util")
 
+local locale_prefix = "glutenfree-equipment-train-stop."
+
 local EquipmentGrid = {}
 
 -- note: equipment_grid.equipment is based on *insertion* order, you cannot just compare the two and expect them to match!
@@ -19,14 +21,14 @@ end
 function EquipmentGrid.tick_rolling_stock(entry, entity)
 
   local grid = entity.grid
-  if not grid then return EquipmentGrid.flying_text(entry.train_stop, "No equipment grid found.") end
+  if not grid then return EquipmentGrid.flying_text(entry.train_stop, {locale_prefix .. "no-equipment-grid"}) end
 
   local template_inventory = entry.template_container.get_inventory(defines.inventory.chest)
-  if template_inventory.is_empty() then return EquipmentGrid.flying_text(entry.train_stop, "Template chest is empty.") end
+  if template_inventory.is_empty() then return EquipmentGrid.flying_text(entry.train_stop, {locale_prefix .. "template-chest-empty"}) end
 
   local template = template_inventory.find_item_stack(prototypes.entity[entity.name].items_to_place_this[1].name)
-  if not template then return EquipmentGrid.flying_text(entry.train_stop, "Missing template for ".. string.gsub(entity.name, "%-", " ") ..".") end
-  if not template.grid then return EquipmentGrid.flying_text(entry.train_stop, "Template equipment grid empty.") end
+  if not template then return EquipmentGrid.flying_text(entry.train_stop, {locale_prefix .. "missing-template", {"entity-name." .. entity.name}}) end
+  if not template.grid then return EquipmentGrid.flying_text(entry.train_stop, {locale_prefix .. "template-equipment-grid-empty"}) end
 
   local contents = get_contents_with_quality_map(grid)
   -- {


### PR DESCRIPTION
Fixes #14 

- #14

---

Replaces the existing hardcoded messages with translatable messages.