### PR TITLE
Use distinct technology

### DIFF
--- a/mods_2.0/040_glutenfree-equipment-train-stop/data.lua
+++ b/mods_2.0/040_glutenfree-equipment-train-stop/data.lua
@@ -6,6 +6,7 @@ mod_prefix = 'glutenfree-equipment-train-stop-'
 require('prototypes.recipes')
 require('prototypes.items')
 require('prototypes.entities')
+require('prototypes.technologies')
 
 flib = nil
 mod_prefix = nil

--- a/mods_2.0/040_glutenfree-equipment-train-stop/locale/de/lang.cfg
+++ b/mods_2.0/040_glutenfree-equipment-train-stop/locale/de/lang.cfg
@@ -3,6 +3,12 @@ glutenfree-equipment-train-stop-tripwire=Auslöser
 glutenfree-equipment-train-stop-station=Ausrüstende Zughaltestelle
 glutenfree-equipment-train-stop-template-container=Schablonen für ausrüstende Zughaltestelle
 
+[technology-name]
+glutenfree-equipment-train-stop=Ausrüstende Zughaltestellen
+
+[technology-description]
+glutenfree-equipment-train-stop=Ermöglicht das Platzieren von Zughaltestellen, an denen Züge gemäß hinterlegten Ausrüstungsvorlagen automatisch ausgestattet werden können.
+
 [glutenfree-equipment-train-stop]
 no-equipment-grid-found=Kein Ausrüstungsraster gefunden.
 template-chest-is-empty=Schablonenkiste ist leer.

--- a/mods_2.0/040_glutenfree-equipment-train-stop/locale/en/lang.cfg
+++ b/mods_2.0/040_glutenfree-equipment-train-stop/locale/en/lang.cfg
@@ -3,6 +3,12 @@ glutenfree-equipment-train-stop-tripwire=Tripwire
 glutenfree-equipment-train-stop-station=Equipment train stop
 glutenfree-equipment-train-stop-template-container=Equipment train stop templates
 
+[technology-name]
+glutenfree-equipment-train-stop=Equipment train stops
+
+[technology-description]
+glutenfree-equipment-train-stop=Allows placing train stops where trains can automatically be equipped according to predefined equipment templates.
+
 [glutenfree-equipment-train-stop]
 no-equipment-grid-found=No equipment grid found.
 template-chest-is-empty=Template chest is empty.

--- a/mods_2.0/040_glutenfree-equipment-train-stop/prototypes/recipes.lua
+++ b/mods_2.0/040_glutenfree-equipment-train-stop/prototypes/recipes.lua
@@ -4,9 +4,4 @@ equipment_train_stop.ingredients = {
   {type = "item", name = "steel-chest", amount = 1},
 }
 
-table.insert(data.raw["technology"]["automated-rail-transportation"].effects, {
-  type = "unlock-recipe",
-  recipe = "glutenfree-equipment-train-stop-station",
-})
-
 data:extend({equipment_train_stop})

--- a/mods_2.0/040_glutenfree-equipment-train-stop/prototypes/technologies.lua
+++ b/mods_2.0/040_glutenfree-equipment-train-stop/prototypes/technologies.lua
@@ -1,0 +1,48 @@
+data:extend({
+  {
+    type = "technology",
+    name = "glutenfree-equipment-train-stop",
+    icons = {
+      {
+        icon = "__base__/graphics/technology/railway.png",
+        icon_size = 256,
+      },
+      {
+        icon = "__base__/graphics/icons/arrows/up-arrow.png",
+        icon_size = 64,
+        shift = {30, 20},
+        scale = 1.5,
+        floating = true,
+        tint = {r = 0, g = 0, b = 0, a = 1},
+      },
+      {
+        icon = "__base__/graphics/icons/arrows/up-arrow.png",
+        icon_size = 64,
+        shift = {30, 20},
+        scale = 1.4,
+        floating = true,
+        tint = {r = 0, g = 0.9, b = 0, a = 1},
+      },
+    },
+    prerequisites = {
+      "solar-panel-equipment",
+      "automated-rail-transportation",
+      "robotics",
+    },
+    effects = {
+      {
+        type = "unlock-recipe",
+        recipe = "glutenfree-equipment-train-stop-station",
+      },
+    },
+    unit = {
+      count = 100,
+      ingredients = {
+        {"automation-science-pack", 1},
+        {"logistic-science-pack", 1},
+        {"chemical-science-pack", 1},
+      },
+      time = 30
+    },
+  },
+})


### PR DESCRIPTION
Fixes #6 

- #6

---

Adds a new technology that unlocks the equipment train station.

<img width="136" height="200" alt="grafik" src="https://github.com/user-attachments/assets/88ae6806-87e8-4d56-b0f9-d709291c1fca" />
<img width="136" height="200" alt="grafik" src="https://github.com/user-attachments/assets/1f95a7fe-55d3-4d6d-88be-31c3f3b296c0" />
<img width="136" height="200" alt="grafik" src="https://github.com/user-attachments/assets/f212db45-9cc8-4a3d-a090-99abe1936767" />
<img width="389" height="453" alt="grafik" src="https://github.com/user-attachments/assets/81e37b8e-b09d-4bbd-95ac-7a172399fc91" />

Feel free to suggest changes to the texts, icons, prequisite and costs.




