### PR TITLE
Fix incompatibility with railway-motor-car

### DIFF
--- a/mods_2.0/040_glutenfree-equipment-train-stop/scripts/equipmentgrid.lua
+++ b/mods_2.0/040_glutenfree-equipment-train-stop/scripts/equipmentgrid.lua
@@ -26,7 +26,11 @@ function EquipmentGrid.tick_rolling_stock(entry, entity)
   local template_inventory = entry.template_container.get_inventory(defines.inventory.chest)
   if template_inventory.is_empty() then return EquipmentGrid.flying_text(entry.train_stop, {locale_prefix .. "template-chest-is-empty"}) end
 
-  local template = template_inventory.find_item_stack({name = prototypes.entity[entity.name].items_to_place_this[1].name, quality = entity.quality})
+  local placement_items = prototypes.entity[entity.name].items_to_place_this
+  if not placement_items or #placement_items == 0 then
+    return -- Nothing the player can do anything about -> silently ignore
+  end
+  local template = template_inventory.find_item_stack({name = placement_items[1].name, quality = entity.quality})
   if not template then return EquipmentGrid.flying_text(entry.train_stop, {locale_prefix .. "missing-template-for", entity.localised_name, entity.quality.localised_name}) end
   if not template.grid then return EquipmentGrid.flying_text(entry.train_stop, {locale_prefix .. "template-equipment-grid-empty"}) end
 


### PR DESCRIPTION
Fixes incompatibility with `railway-motor-car` / vehicles without an associated item to place them.

<img width="539" height="378" alt="grafik" src="https://github.com/user-attachments/assets/05444173-dc0d-4014-9dae-614651bf3b22" />
