### PR TITLE
cargo-bay-inserters: Add support for the stand-alone cargo-bay mod

### DIFF
--- a/mods_2.0/064_cargo-bay-inserters/control.lua
+++ b/mods_2.0/064_cargo-bay-inserters/control.lua
@@ -210,7 +210,7 @@ end
 
 script.on_event(defines.events.on_entity_died, function(event)
   if event.entity.name == "cargo-bay" then
-    local proxy = event.entity.surface.find_entity(platform_cargo_bay_proxy_name, event.entity.position)
+    local proxy = event.entity.surface.find_entity(event.entity.surface.platform and platform_cargo_bay_proxy_name or planet_cargo_bay_proxy_name, event.entity.position)
     if proxy then
       proxy.destroy()
     end

--- a/mods_2.0/064_cargo-bay-inserters/data-final-fixes.lua
+++ b/mods_2.0/064_cargo-bay-inserters/data-final-fixes.lua
@@ -1,17 +1,18 @@
-local platform_proxy = data.raw["proxy-container"][mod_prefix .. "platform-cargo-bay-proxy"]
-local planet_proxy = data.raw["proxy-container"][mod_prefix .. "planet-cargo-bay-proxy"]
-
 local should_copy_flag = {
   ["no-automated-item-insertion"] = true,
   ["no-automated-item-removal"] = true,
 }
 
-for _, flag in ipairs(data.raw["space-platform-hub"]["space-platform-hub"].flags or {}) do
-  if should_copy_flag[flag] then
-    table.insert(platform_proxy.flags, flag)
+if mods["space-age"] then
+  local platform_proxy = data.raw["proxy-container"][mod_prefix .. "platform-cargo-bay-proxy"]
+  for _, flag in ipairs(data.raw["space-platform-hub"]["space-platform-hub"].flags or {}) do
+    if should_copy_flag[flag] then
+      table.insert(platform_proxy.flags, flag)
+    end
   end
 end
 
+local planet_proxy = data.raw["proxy-container"][mod_prefix .. "planet-cargo-bay-proxy"]
 for _, flag in ipairs(data.raw["cargo-landing-pad"]["cargo-landing-pad"].flags or {}) do
   if should_copy_flag[flag] then
     table.insert(planet_proxy.flags, flag)

--- a/mods_2.0/064_cargo-bay-inserters/data.lua
+++ b/mods_2.0/064_cargo-bay-inserters/data.lua
@@ -2,12 +2,12 @@ require("shared")
 
 local proxy_tint = {0.8, 0.1, 0.3}
 
-local platform_cargo_bay = {
+local planet_cargo_bay = {
   type = "proxy-container",
-  name = mod_prefix .. "platform-cargo-bay-proxy",
+  name = mod_prefix .. "planet-cargo-bay-proxy",
 
   icons = {
-    {icon = "__space-age__/graphics/icons/space-platform-hub.png", tint = proxy_tint}
+    {icon = "__base__/graphics/icons/cargo-landing-pad.png", tint = proxy_tint}
   },
 
   -- matches the boxes of the cargo bay
@@ -22,9 +22,12 @@ local platform_cargo_bay = {
   selection_priority = 49,
   hidden = true,
 }
+data:extend{planet_cargo_bay}
 
-local planet_cargo_bay = table.deepcopy(platform_cargo_bay)
-planet_cargo_bay.name = mod_prefix .. "planet-cargo-bay-proxy"
-planet_cargo_bay.icons[1].icon = "__base__/graphics/icons/cargo-landing-pad.png"
+if mods["space-age"] then
+  local platform_cargo_bay = table.deepcopy(planet_cargo_bay)
+  platform_cargo_bay.name = mod_prefix .. "platform-cargo-bay-proxy"
+  platform_cargo_bay.icons[1].icon = "__space-age__/graphics/icons/space-platform-hub.png"
 
-data:extend{platform_cargo_bay, planet_cargo_bay}
+  data:extend{platform_cargo_bay}
+end

--- a/mods_2.0/064_cargo-bay-inserters/info.json
+++ b/mods_2.0/064_cargo-bay-inserters/info.json
@@ -19,6 +19,7 @@
         "? newsletter-for-mods-made-by-quezler",
 
         "base >= 2.0.46",
-        "space-age"
+        "? space-age",
+        "? cargo-bay"
     ]
 }


### PR DESCRIPTION
I extracted the cargo-bay entity from space-age in in order to be able to mega base more than 30 rockets incoming on a non-space-age game.  Having cargo-bay-inserters work here would be nice too.