### PR TITLE
Detect when a lab does not support all of the needed science packs and ignore that lab in full in that case

### DIFF
--- a/mods_2.0/052_show-missing-bottles-for-current-research/control.lua
+++ b/mods_2.0/052_show-missing-bottles-for-current-research/control.lua
@@ -116,13 +116,20 @@ local function get_missing_counts(force, list)
           local inventory = struct.entity.get_inventory(defines.inventory.lab_input)
           if inventory.is_empty() == false then
 
-            local get_item_count = {} -- qualities summed together
-            for _, item in ipairs(inventory.get_contents()) do
-              get_item_count[item.name] = (get_item_count[item.name] or 0) + item.count
+            local supported_lab = true
+            for _, item_name in ipairs(list) do
+              if not storage.lab_inputs[struct.entity.name][item_name] then -- ignore labs that cannot use this item
+                supported_lab = false
+              end
             end
 
-            for _, item_name in ipairs(list) do
-              if storage.lab_inputs[struct.entity.name][item_name] then -- ignore labs that cannot use this item
+            if supported_lab then
+              local get_item_count = {} -- qualities summed together
+              for _, item in ipairs(inventory.get_contents()) do
+                get_item_count[item.name] = (get_item_count[item.name] or 0) + item.count
+              end
+
+              for _, item_name in ipairs(list) do
                 if get_item_count[item_name] == nil then
                   -- game.print(serpent.line({
                   --   item_name,


### PR DESCRIPTION
Detect when a lab does not support all of the needed science packs and ignore that lab in full in that case.

In essence, factored out the check for if the lab supports all of the needed science items first and skip the rest if any are missing.  Did it this way so as to not introduce potentially hard to follow `goto`'s and also to make the logic more obvious.